### PR TITLE
Add config.w32 for building on Windows

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,29 @@
+ARG_ENABLE("spx", "whether to enable SPX extension", "no");
+
+if (PHP_SPX != "no") {
+    if (PHP_ZTS == "yes") {
+        ERROR("SPX does not work with ZTS PHP build");
+    }
+    if (CHECK_LIB("zlib_a.lib;zlib.lib", "zlib", PHP_SPX) &&
+        CHECK_HEADER_ADD_INCLUDE("zlib.h", "CFLAGS", "..\\zlib;" + php_usual_include_suspects)) {
+        AC_DEFINE("HAVE_SPX", 1, "Define to 1 if the PHP extension 'spx' is available.");
+        EXTENSION("spx",
+            "src/php_spx.c " +
+            "src/spx_profiler.c " +
+            "src/spx_profiler_tracer.c " +
+            "src/spx_profiler_sampler.c " +
+            "src/spx_reporter_full.c " +
+            "src/spx_reporter_fp.c " +
+            "src/spx_reporter_trace.c " +
+            "src/spx_metric.c " +
+            "src/spx_resource_stats.c " +
+            "src/spx_hmap.c " +
+            "src/spx_str_builder.c " +
+            "src/spx_output_stream.c " +
+            "src/spx_php.c " +
+            "src/spx_stdio.c " +
+            "src/spx_config.c " +
+            "src/spx_utils.c " +
+            "src/spx_fmt.c");
+    }
+}


### PR DESCRIPTION
This is just a most basic configuration; Windows builds are not yet supposed to succeed for various reasons.

---

Log when building against PHP 8.3.9 (Windows x86):
````
        "cl.exe" /D ZEND_COMPILE_DL_EXT=1 /D COMPILE_DL_SPX /D SPX_EXPORTS=1 /nologo /I C:\php\php-8.3.9-devel-vs16-x64/include /I C:\php\php-8.3.9-devel-vs16-x64/include/main /I C:\php\php-8.3.9-devel-vs16-x64/include/Zend /I C:\php\php-8.3.9-devel-vs16-x64/include/TSRM /I C:\php\php-8.3.9-devel-vs16-x64/include/ext /D _WINDOWS /D WINDOWS=1 /D ZEND_WIN32=1 /D PHP_WIN32=1 /D WIN32 /D _MBCS /D _USE_MATH_DEFINES /FD /wd4996 /D_USE_32BIT_TIME_T=1 /Qspectre /guard:cf /Zc:inline /Zc:__cplusplus /d2FuncCache1 /Zc:wchar_t /MP /LD /MD /Ox /D NDebug /D NDEBUG /GF /D ZEND_DEBUG=0 /I "C:\php-sdk\phpdev\vs16\x64\deps-8.3\include" /FoD:\Users\cmb\Downloads\php-spx-0.4.16\Release\\ /FpD:\Users\cmb\Downloads\php-spx-0.4.16\Release\\ /FRD:\Users\cmb\Downloads\php-spx-0.4.16\Release\\ /FdD:\Users\cmb\Downloads\php-spx-0.4.16\Release\\ /c D:\Users\cmb\Downloads\php-spx-0.4.16\src/php_spx.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_config.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_fmt.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_hmap.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_metric.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_output_stream.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_profiler.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_profiler_sampler.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_profiler_tracer.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_reporter_fp.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_reporter_full.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_reporter_trace.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_resource_stats.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_stdio.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_str_builder.c D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_utils.c
php_spx.c
spx_config.c
spx_fmt.c
spx_hmap.c
spx_metric.c
spx_output_stream.c
spx_php.c
spx_profiler.c
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_fmt.c(193): warning C4129: "e": nicht erkannte Folge von Escapesequenz
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_fmt.c(207): warning C4129: "e": nicht erkannte Folge von Escapesequenz
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_metric.c(30): fatal error C1189: #error:  "Please open an issue"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/php_spx.c(20): fatal error C1083: Datei (Include) kann nicht geöffnet werden: "unistd.h": No such file or directory
spx_profiler_sampler.c
spx_profiler_tracer.c
spx_reporter_fp.c
spx_reporter_full.c
spx_reporter_trace.c
spx_resource_stats.c
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_resource_stats.c(26): fatal error C1189: #error:  "Your platform is not supported. Please open an issue."
spx_stdio.c
spx_str_builder.c
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_profiler_sampler.c(21): fatal error C1083: Datei (Include) kann nicht geöffnet werden: "pthread.h": No such file or directory
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_stdio.c(20): fatal error C1189: #error:  "Your platform is not supported"
spx_utils.c
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_reporter_fp.c(23): fatal error C1083: Datei (Include) kann nicht geöffnet werden: "unistd.h": No such file or directory
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_reporter_full.c(24): fatal error C1083: Datei (Include) kann nicht geöffnet werden: "unistd.h": No such file or directory
C:\php\php-8.3.9-devel-vs16-x64\include\main\config.w32.h(148): warning C4005: "PHP_BUILD_SYSTEM": Makro-Neudefinition (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include\main/config.pickle.h(8): note: Siehe vorherige Definition von "PHP_BUILD_SYSTEM" (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64\include\main\config.w32.h(160): warning C4005: "PHP_BUILD_ARCH": Makro-Neudefinition (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include\main/config.pickle.h(12): note: Siehe vorherige Definition von "PHP_BUILD_ARCH" (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64\include\main\config.w32.h(148): warning C4005: "PHP_BUILD_SYSTEM": Makro-Neudefinition (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include\main/config.pickle.h(8): note: Siehe vorherige Definition von "PHP_BUILD_SYSTEM" (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64\include\main\config.w32.h(160): warning C4005: "PHP_BUILD_ARCH": Makro-Neudefinition (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include\main/config.pickle.h(12): note: Siehe vorherige Definition von "PHP_BUILD_ARCH" (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include/main\config.w32.h(148): warning C4005: "PHP_BUILD_SYSTEM": Makro-Neudefinition (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include\main/config.pickle.h(8): note: Siehe vorherige Definition von "PHP_BUILD_SYSTEM" (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include/main\config.w32.h(160): warning C4005: "PHP_BUILD_ARCH": Makro-Neudefinition (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
C:\php\php-8.3.9-devel-vs16-x64/include\main/config.pickle.h(12): note: Siehe vorherige Definition von "PHP_BUILD_ARCH" (Quelldatei wird kompiliert D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c)
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(118): error C2146: Syntaxfehler: Fehlendes ")" vor Bezeichner "error_lineno"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(118): error C2146: Syntaxfehler: Fehlendes ";" vor Bezeichner "error_lineno"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(118): error C2061: Syntaxfehler: Bezeichner "error_lineno"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(125): error C2059: Syntaxfehler: ")"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(126): error C2059: Syntaxfehler: "}"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(228): error C2146: Syntaxfehler: Fehlendes ")" vor Bezeichner "error_lineno"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(228): error C2061: Syntaxfehler: Bezeichner "error_lineno"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(228): error C2059: Syntaxfehler: ";"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(228): error C2059: Syntaxfehler: ","
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(235): error C2059: Syntaxfehler: ")"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(408): error C2121: "#": ungültiges Zeichen: möglicherweise das Ergebnis einer Makroerweiterung
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(408): error C2059: Syntaxfehler: "Konstante"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(408): error C2181: Ungültiges "else" ohne zugehöriges "if"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(408): error C2065: "endif": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(408): error C2143: Syntaxfehler: Es fehlt ";" vor "if"
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(572): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(572): error C2224: Der linke Teil von ".execute_ex" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(576): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(576): error C2224: Der linke Teil von ".previous_zend_execute_internal" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(577): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(577): error C2224: Der linke Teil von ".execute_internal" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(582): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(582): error C2224: Der linke Teil von ".zend_compile_file" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(585): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(585): error C2224: Der linke Teil von ".zend_compile_string" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(589): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(589): error C2224: Der linke Teil von ".gc_collect_cycles" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(593): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(593): error C2224: Der linke Teil von ".zend_error_cb" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(594): error C2065: "global_hook_zend_error_cb": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(594): warning C4047: "=": Anzahl der Dereferenzierungen bei "void (__cdecl *)(int,zend_string *,const uint32_t,zend_string *)" und "int" unterschiedlich
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(605): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(605): error C2224: Der linke Teil von ".execute_ex" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(606): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(606): error C2224: Der linke Teil von ".execute_ex" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(607): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(607): error C2224: Der linke Teil von ".execute_ex" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(611): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(611): error C2224: Der linke Teil von ".execute_internal" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(612): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(612): error C2224: Der linke Teil von ".previous_zend_execute_internal" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(613): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(613): error C2224: Der linke Teil von ".previous_zend_execute_internal" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(614): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(614): error C2224: Der linke Teil von ".execute_internal" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(617): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(617): error C2224: Der linke Teil von ".zend_compile_file" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(618): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(618): error C2224: Der linke Teil von ".zend_compile_file" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(619): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(619): error C2224: Der linke Teil von ".zend_compile_file" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(622): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(622): error C2224: Der linke Teil von ".zend_compile_string" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(623): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(623): error C2224: Der linke Teil von ".zend_compile_string" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(624): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(624): error C2224: Der linke Teil von ".zend_compile_string" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(628): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(628): error C2224: Der linke Teil von ".gc_collect_cycles" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(629): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(629): error C2224: Der linke Teil von ".gc_collect_cycles" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(630): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(630): error C2224: Der linke Teil von ".gc_collect_cycles" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(634): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(634): error C2224: Der linke Teil von ".zend_error_cb" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(635): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(635): error C2224: Der linke Teil von ".zend_error_cb" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(636): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(636): error C2224: Der linke Teil von ".zend_error_cb" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(669): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(669): error C2224: Der linke Teil von ".malloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(670): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(670): error C2224: Der linke Teil von ".free" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(671): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(671): error C2224: Der linke Teil von ".realloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(667): error C2198: "zend_mm_get_custom_handlers": Nicht genügend Argumente für Aufruf.
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(674): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(674): error C2224: Der linke Teil von ".block_size" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(677): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(677): error C2224: Der linke Teil von ".malloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(678): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(678): error C2224: Der linke Teil von ".free" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(679): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(679): error C2224: Der linke Teil von ".realloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(681): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(681): error C2224: Der linke Teil von ".malloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(682): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(682): error C2224: Der linke Teil von ".free" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(683): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(683): error C2224: Der linke Teil von ".realloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(684): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(684): error C2224: Der linke Teil von ".block_size" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(700): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(700): error C2224: Der linke Teil von ".malloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(701): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(701): error C2224: Der linke Teil von ".free" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(702): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(702): error C2224: Der linke Teil von ".realloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(711): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(711): error C2224: Der linke Teil von ".malloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(715): error C2065: "ze_hooked_func": nichtdeklarierter Bezeichner
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(715): error C2224: Der linke Teil von ".malloc" muss eine Struktur/Union sein
D:\Users\cmb\Downloads\php-spx-0.4.16\src/spx_php.c(715): fatal error C1003: Mehr als 100 Fehler gefunden; Kompilierung wird abgebrochen.
NMAKE : fatal error U1077: ""C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.29.30133\bin\HostX86\x86\cl.exe"": Rückgabe-Code "0x2"
Stop.
````
I haven't checked that closely, but there appear to be the following issues at least:
* `#error` directives because MSVC is not supported
* reliance on phtreads which is not checked in config.m4 either
* attempted inclusion of unistd.h which is not available on Windows